### PR TITLE
Add working directory for task

### DIFF
--- a/T7EPreferences/JumpListItemObject.cs
+++ b/T7EPreferences/JumpListItemObject.cs
@@ -102,6 +102,7 @@ namespace T7EPreferences
                                      // UI shows TaskAHKTextBox, and this is empty.
         public string TaskCMDPath = "";
         public string TaskCMDArgs = "";
+        public string TaskCMDWorkDir = "";
         public bool TaskCMDShowWindow = false;
 
         public bool TaskKBDShortcutMode = true;
@@ -347,6 +348,11 @@ namespace T7EPreferences
             TaskKBDString = taskKBDString;
         }
 
+        public void StringToItemWorkDir(string cmdWorkDir)
+        {
+            TaskCMDWorkDir = cmdWorkDir;
+        }
+
         public void StringToItemCmd(string cmdString)
         {
             string cmdLine = cmdString.Trim();
@@ -426,6 +432,11 @@ namespace T7EPreferences
                     "\"" + cmdArg1 + "\" " + cmdArgRest
                     : cmdArg1 + " " + cmdArgRest;
             }
+        }
+
+        public string ItemWorkDirToString()
+        {
+            return TaskCMDWorkDir;
         }
 
         public string ItemCmdToString()

--- a/T7EPreferences/Preferences.cs
+++ b/T7EPreferences/Preferences.cs
@@ -267,6 +267,7 @@ namespace T7EPreferences
                 case T7EJumplistItem.ActionType.CommandLine:
                     xmlWriter.WriteAttributeString("type", "T7E_TYPE_CMD");
                     xmlWriter.WriteAttributeString("showWindow", jumplistItem.TaskCMDShowWindow.ToString());
+                    xmlWriter.WriteAttributeString("workingDir", jumplistItem.ItemWorkDirToString());
                     if(isPack)
                         xmlWriter.WriteValue(ReplacePathsToVars(jumplistItem.ItemCmdToString()));
                     else
@@ -492,13 +493,14 @@ namespace T7EPreferences
                     {
                         task.Path = "cmd.exe";
                         task.Arguments = "/k \"" + jumplistItem.ItemCmdToString().Replace("\"", "\"\"") + "\"";
-                        // I'm not sure if this is right, but for any executable, set workingdir to the exe path.
-                        task.WorkingDirectory = Path.GetDirectoryName(jumplistItem.TaskCMDPath);
                     } else {
                         task.Path = jumplistItem.TaskCMDPath;
                         task.Arguments = jumplistItem.TaskCMDArgs;
-                        task.WorkingDirectory = Path.GetDirectoryName(jumplistItem.TaskCMDPath);
                     }
+                    if (string.IsNullOrEmpty(jumplistItem.TaskCMDWorkDir))
+                        task.WorkingDirectory = Path.GetDirectoryName(jumplistItem.TaskCMDPath);
+                    else
+                        task.WorkingDirectory = jumplistItem.TaskCMDWorkDir;
                     break;
 
                 case T7EJumplistItem.ActionType.AutoHotKey:

--- a/T7EPreferences/Primary.Designer.cs
+++ b/T7EPreferences/Primary.Designer.cs
@@ -92,6 +92,8 @@ namespace T7EPreferences
             this.TaskCMDBrowseButton = new System.Windows.Forms.Button();
             this.TaskCMDShowWindowCheckbox = new System.Windows.Forms.CheckBox();
             this.TaskCMDTextBox = new System.Windows.Forms.TextBox();
+            this.TaskCMDWorkDirLabel = new System.Windows.Forms.Label();
+            this.TaskCMDWorkdirTextBox = new System.Windows.Forms.TextBox();
             this.TaskCMDLabel = new System.Windows.Forms.Label();
             this.TaskAHKPanel = new System.Windows.Forms.Panel();
             this.TaskAHKHelpButton = new System.Windows.Forms.Button();
@@ -732,6 +734,8 @@ namespace T7EPreferences
             this.TaskCMDPanel.Controls.Add(this.TaskCMDShowWindowCheckbox);
             this.TaskCMDPanel.Controls.Add(this.TaskCMDTextBox);
             this.TaskCMDPanel.Controls.Add(this.TaskCMDLabel);
+            this.TaskCMDPanel.Controls.Add(this.TaskCMDWorkdirTextBox);
+            this.TaskCMDPanel.Controls.Add(this.TaskCMDWorkDirLabel);
             this.TaskCMDPanel.Enabled = false;
             this.TaskCMDPanel.Location = new System.Drawing.Point(0, 40);
             this.TaskCMDPanel.Margin = new System.Windows.Forms.Padding(2);
@@ -767,7 +771,7 @@ namespace T7EPreferences
             // TaskCMDShowWindowCheckbox
             // 
             this.TaskCMDShowWindowCheckbox.AutoSize = true;
-            this.TaskCMDShowWindowCheckbox.Location = new System.Drawing.Point(30, 50);
+            this.TaskCMDShowWindowCheckbox.Location = new System.Drawing.Point(30, 100);
             this.TaskCMDShowWindowCheckbox.Margin = new System.Windows.Forms.Padding(2);
             this.TaskCMDShowWindowCheckbox.Name = "TaskCMDShowWindowCheckbox";
             this.TaskCMDShowWindowCheckbox.Size = new System.Drawing.Size(172, 17);
@@ -797,6 +801,28 @@ namespace T7EPreferences
             this.TaskCMDLabel.Size = new System.Drawing.Size(93, 13);
             this.TaskCMDLabel.TabIndex = 0;
             this.TaskCMDLabel.Text = "Comman&d Line:";
+            // 
+            // TaskCMDWorkdirTextBox
+            // 
+            this.TaskCMDWorkdirTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.TaskCMDWorkdirTextBox.Location = new System.Drawing.Point(7, 75);
+            this.TaskCMDWorkdirTextBox.Margin = new System.Windows.Forms.Padding(2);
+            this.TaskCMDWorkdirTextBox.Name = "TaskCMDWorkdirTextBox";
+            this.TaskCMDWorkdirTextBox.Size = new System.Drawing.Size(304, 20);
+            this.TaskCMDWorkdirTextBox.TabIndex = 1;
+            this.TaskCMDWorkdirTextBox.Leave += new System.EventHandler(this.TaskCMDWorkDirTextBox_Leave);
+            // 
+            // TaskCMDWorkDirLabel
+            // 
+            this.TaskCMDWorkDirLabel.AutoSize = true;
+            this.TaskCMDWorkDirLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.TaskCMDWorkDirLabel.Location = new System.Drawing.Point(5, 57);
+            this.TaskCMDWorkDirLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.TaskCMDWorkDirLabel.Name = "TaskCMDWorkDirLabel";
+            this.TaskCMDWorkDirLabel.Size = new System.Drawing.Size(111, 13);
+            this.TaskCMDWorkDirLabel.TabIndex = 0;
+            this.TaskCMDWorkDirLabel.Text = "Working Directory:";
             // 
             // TaskAHKPanel
             // 
@@ -1485,6 +1511,8 @@ namespace T7EPreferences
         private System.Windows.Forms.CheckBox TaskCMDShowWindowCheckbox;
         private System.Windows.Forms.TextBox TaskCMDTextBox;
         private System.Windows.Forms.Label TaskCMDLabel;
+        private System.Windows.Forms.TextBox TaskCMDWorkdirTextBox;
+        private System.Windows.Forms.Label TaskCMDWorkDirLabel;
         private System.Windows.Forms.Panel ItemPanel;
         private System.Windows.Forms.ComboBox ItemTypeComboBox;
         private System.Windows.Forms.Label ItemTypeLabel;

--- a/T7EPreferences/Primary.cs
+++ b/T7EPreferences/Primary.cs
@@ -858,12 +858,14 @@ namespace T7EPreferences
                                     case "T7E_TYPE_CMD":
                                         jumplistItem.TaskAction = T7EJumplistItem.ActionType.CommandLine;
                                         bool.TryParse(reader["showWindow"], out jumplistItem.TaskCMDShowWindow);
+                                        string workdirString = reader["workingDir"] ?? string.Empty;
                                         reader.Read(); // Read to text node
                                         string cmdString = "";
                                         if (PackLoading) cmdString = Preferences.ReplaceVarsToPaths(reader.Value);
                                         else cmdString = Common.ReplaceEnvVarToExpandedPath(reader.Value);
 
                                         jumplistItem.StringToItemCmd(cmdString);
+                                        jumplistItem.StringToItemWorkDir(workdirString);
                                         break;
 
                                     case "T7E_TYPE_AHK":
@@ -1014,6 +1016,7 @@ namespace T7EPreferences
                 TaskKBDSwitchToTextMode();
             //
             TaskCMDTextBox.Text = _CurrentJumplistItem.ItemCmdToString();
+            TaskCMDWorkdirTextBox.Text = _CurrentJumplistItem.ItemWorkDirToString();
             TaskCMDShowWindowCheckbox.Checked = _CurrentJumplistItem.TaskCMDShowWindow;
             //
             TaskAHKTextBox.Text = _CurrentJumplistItem.TaskAHKScript;
@@ -1936,6 +1939,11 @@ namespace T7EPreferences
         private void TaskCMDTextBox_Leave(object sender, EventArgs e)
         {
             CurrentJumplistItem.StringToItemCmd(TaskCMDTextBox.Text);
+        }
+
+        private void TaskCMDWorkDirTextBox_Leave(object sender, EventArgs e)
+        {
+            CurrentJumplistItem.StringToItemWorkDir(TaskCMDWorkdirTextBox.Text);
         }
 
         private void TaskCMDShowWindowCheckbox_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
This allows the user to change the working directory for a CMD task.

Looks like a cool feature. I have not tested it personally. The GUI size and coordinates may be slightly wrong, due to WinForms scaling.

Will merge if someone verifies that:

1. The GUI coordinates are acceptable (please provide a screenshot)
2. This builds successfully.
3. The editor works correctly.
4. The task works in the jump list.

(pulled from ivan-danilov/jumplist-extender@9ade442345f77949e7b06e8963da4938faca1eac, thank you!)